### PR TITLE
feat: add pagination and favorites page

### DIFF
--- a/pokedex-app/package-lock.json
+++ b/pokedex-app/package-lock.json
@@ -22,7 +22,9 @@
         "@capacitor/keyboard": "7.0.1",
         "@capacitor/status-bar": "7.0.1",
         "@ionic/angular": "^8.0.0",
+        "@ionic/storage-angular": "^4.0.0",
         "ionicons": "^7.0.0",
+        "ngx-pagination": "^6.0.3",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -3991,6 +3993,29 @@
         "@stencil/core": "4.33.1",
         "ionicons": "^7.2.2",
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@ionic/storage": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@ionic/storage/-/storage-4.0.0.tgz",
+      "integrity": "sha512-3N21P19Xk6cICLnSXZ3ilRqbSXAGSFeIF3HNqz+1kARcm0UFT/vwmZreaXtFyq437vvEWOfJ2enlj3JHLKS0FA==",
+      "license": "MIT",
+      "dependencies": {
+        "localforage": "^1.9.0"
+      }
+    },
+    "node_modules/@ionic/storage-angular": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@ionic/storage-angular/-/storage-angular-4.0.0.tgz",
+      "integrity": "sha512-FeSmCMCm1bMRfu5TFSqLtjdfEo/dLLUhLIrPmbhSYomVZdV/dNn4mBZv9SabyxSqn4bF31hw40y+4buhG+durQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/storage": "^4.0.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "*",
+        "rxjs": "*"
       }
     },
     "node_modules/@ionic/utils-array": {
@@ -11008,6 +11033,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immutable": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
@@ -12548,6 +12579,15 @@
         }
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -12656,6 +12696,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {
@@ -13456,6 +13505,19 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ngx-pagination": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ngx-pagination/-/ngx-pagination-6.0.3.tgz",
+      "integrity": "sha512-lONjTQ7hFPh1SyhwDrRd5ZwM4NMGQ7bNR6vLrs6mrU0Z8Q1zCcWbf/pvyp4DOlGyd9uyZxRy2wUsSZLeIPjbAw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=13.0.0",
+        "@angular/core": ">=13.0.0"
+      }
     },
     "node_modules/node-addon-api": {
       "version": "6.1.0",

--- a/pokedex-app/package.json
+++ b/pokedex-app/package.json
@@ -27,7 +27,9 @@
     "@capacitor/keyboard": "7.0.1",
     "@capacitor/status-bar": "7.0.1",
     "@ionic/angular": "^8.0.0",
+    "@ionic/storage-angular": "^4.0.0",
     "ionicons": "^7.0.0",
+    "ngx-pagination": "^6.0.3",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/pokedex-app/src/app/app.component.spec.ts
+++ b/pokedex-app/src/app/app.component.spec.ts
@@ -1,14 +1,21 @@
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { AppComponent } from './app.component';
+import { IonicStorageModule } from '@ionic/storage-angular';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('AppComponent', () => {
-  it('should create the app', async () => {
+  beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AppComponent],
-      providers: [provideRouter([])]
+      imports: [AppComponent, IonicStorageModule.forRoot()],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(), // Adicione se estiver usando HttpClient
+      ],
     }).compileComponents();
-    
+  });
+
+  it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();

--- a/pokedex-app/src/app/app.component.ts
+++ b/pokedex-app/src/app/app.component.ts
@@ -1,10 +1,12 @@
 import { Component } from '@angular/core';
 import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
+import { NgxPaginationModule } from 'ngx-pagination';
+import { IonicStorageModule } from '@ionic/storage-angular';
 
 @Component({
   selector: 'app-root',
   templateUrl: 'app.component.html',
-  imports: [IonApp, IonRouterOutlet],
+  imports: [IonApp, IonRouterOutlet, NgxPaginationModule, IonicStorageModule],
 })
 export class AppComponent {
   constructor() {}

--- a/pokedex-app/src/app/app.config.ts
+++ b/pokedex-app/src/app/app.config.ts
@@ -1,0 +1,22 @@
+import { ApplicationConfig } from '@angular/core';
+import { 
+  RouteReuseStrategy, 
+  provideRouter, 
+  withPreloading, 
+  PreloadAllModules,
+  RouterModule
+} from '@angular/router';
+import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular/standalone';
+import { provideHttpClient } from '@angular/common/http';
+import { Storage } from '@ionic/storage-angular';
+import { routes } from './app.routes'; // Importação adicionada aqui
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
+    provideIonicAngular(),
+    provideRouter(routes, withPreloading(PreloadAllModules)), // Agora routes está definido
+    provideHttpClient(),
+    { provide: Storage, useFactory: () => new Storage() }
+  ]
+};

--- a/pokedex-app/src/app/app.routes.ts
+++ b/pokedex-app/src/app/app.routes.ts
@@ -14,4 +14,8 @@ export const routes: Routes = [
     redirectTo: 'home',
     pathMatch: 'full',
   },
+  {
+    path: 'favorites',
+    loadComponent: () => import('./favorites/favorites.page').then( m => m.FavoritesPage)
+  },
 ];

--- a/pokedex-app/src/app/favorites/favorites.page.html
+++ b/pokedex-app/src/app/favorites/favorites.page.html
@@ -1,0 +1,34 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Favorite Pokémons</ion-title>
+    <ion-buttons slot="start">
+      <ion-back-button defaultHref="/home"></ion-back-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <div class="pokemon-grid">
+    <ion-card *ngFor="let pokemon of favorites" [class]="'type-' + pokemon.types[0].type.name"
+              (click)="openPokemonDetail(pokemon)">
+      <div class="pokemon-image">
+        <img [src]="pokemon.sprites.front_default" [alt]="pokemon.name" />
+      </div>
+
+      <ion-card-header>
+        <ion-card-title>{{ pokemon.name | titlecase }}</ion-card-title>
+      </ion-card-header>
+
+      <ion-card-content>
+        <span class="pokemon-type">{{ pokemon.types[0].type.name | titlecase }}</span>
+        <ion-button fill="clear" (click)="removeFavorite(pokemon, $event)">
+          <ion-icon name="heart" color="danger"></ion-icon>
+        </ion-button>
+      </ion-card-content>
+    </ion-card>
+  </div>
+
+  <ion-note *ngIf="favorites.length === 0" class="empty-message">
+    No favorite Pokémon yet.
+  </ion-note>
+</ion-content>

--- a/pokedex-app/src/app/favorites/favorites.page.spec.ts
+++ b/pokedex-app/src/app/favorites/favorites.page.spec.ts
@@ -1,0 +1,17 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FavoritesPage } from './favorites.page';
+
+describe('FavoritesPage', () => {
+  let component: FavoritesPage;
+  let fixture: ComponentFixture<FavoritesPage>;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FavoritesPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/pokedex-app/src/app/favorites/favorites.page.ts
+++ b/pokedex-app/src/app/favorites/favorites.page.ts
@@ -1,0 +1,43 @@
+import { Component, OnInit } from '@angular/core';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonCard, 
+         IonCardContent, IonCardHeader, IonCardTitle, IonButton, 
+         IonIcon, IonBackButton, IonNote, IonButtons } from '@ionic/angular/standalone';
+import { CommonModule } from '@angular/common';
+import { FavoritesService } from '../services/favorites.service';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-favorites',
+  templateUrl: './favorites.page.html',
+  styleUrls: ['./favorites.page.scss'],
+  standalone: true,
+  imports: [
+    IonHeader, IonToolbar, IonTitle, IonContent, IonCard, 
+    IonCardContent, IonCardHeader, IonCardTitle, CommonModule, 
+    IonButton, IonIcon, IonBackButton, IonNote, IonButtons
+  ]
+})
+export class FavoritesPage implements OnInit {
+  favorites: any[] = [];
+
+  constructor(
+    private favoritesService: FavoritesService,
+    private router: Router
+  ) {}
+
+  async ngOnInit() {
+    this.favorites = await this.favoritesService.getFavorites();
+  }
+
+  async removeFavorite(pokemon: any, event: Event) {
+    event.stopPropagation();
+    await this.favoritesService.removeFavorite(pokemon.name);
+    this.favorites = await this.favoritesService.getFavorites();
+  }
+
+  openPokemonDetail(pokemon: any) {
+    this.router.navigate(['/pokemon-detail'], {
+      state: { pokemon }
+    });
+  }
+}

--- a/pokedex-app/src/app/home/home.page.html
+++ b/pokedex-app/src/app/home/home.page.html
@@ -1,27 +1,35 @@
 <ion-header [translucent]="true">
   <ion-toolbar>
     <ion-title> Pokédex </ion-title>
+    <ion-buttons slot="end">
+      <ion-button [routerLink]="['/favorites']" routerDirection="forward">
+        <ion-icon name="heart" slot="icon-only"></ion-icon>
+      </ion-button>
+    </ion-buttons>
   </ion-toolbar>
 </ion-header>
 
 <ion-content [fullscreen]="true">
   <div class="pokemon-grid">
-    <ion-card
-      *ngFor="let pokemon of pokemons"
-      [class]="'type-' + pokemon.types[0].type.name"
-      (click)="openPokemonDetail(pokemon)"
-    >
+    <ion-card *ngFor="let pokemon of pokemons | paginate: { itemsPerPage: 50, currentPage: page, totalItems: totalPokemons }"
+              [class]="'type-' + pokemon.types[0].type.name" (click)="openPokemonDetail(pokemon)">
       <div class="pokemon-image">
         <img [src]="pokemon.sprites.front_default" [alt]="pokemon.name" />
       </div>
 
       <ion-card-header>
-        <ion-card-title>{{ pokemon.name }}</ion-card-title>
+        <ion-card-title>{{ pokemon.name | titlecase }}</ion-card-title>
       </ion-card-header>
 
       <ion-card-content>
-        <span class="pokemon-type"> {{ pokemon.types[0].type.name }} </span>
+        <span class="pokemon-type">{{ pokemon.types[0].type.name | titlecase }}</span>
+        <ion-button fill="clear" (click)="toggleFavorite(pokemon, $event)">
+          <ion-icon [name]="isFavorite(pokemon.name) ? 'heart' : 'heart-outline'" 
+                   [color]="isFavorite(pokemon.name) ? 'danger' : 'medium'"></ion-icon>
+        </ion-button>
       </ion-card-content>
     </ion-card>
   </div>
+
+  <pagination-controls (pageChange)="page = $event; pokemons = []; getPokemons()"></pagination-controls>
 </ion-content>

--- a/pokedex-app/src/app/home/home.page.ts
+++ b/pokedex-app/src/app/home/home.page.ts
@@ -1,34 +1,14 @@
-import { Component } from '@angular/core';
-import {
-  IonHeader,
-  IonToolbar,
-  IonTitle,
-  IonContent,
-  IonCard,
-  IonCardContent,
-  IonCardHeader,
-  IonCardTitle,
-  IonSpinner,
-  IonImg,
-  IonBadge,
-  NavController,
-} from '@ionic/angular/standalone';
+import { Component, OnInit } from '@angular/core';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonCard, 
+         IonCardContent, IonCardHeader, IonCardTitle, IonButton, 
+         IonIcon, IonButtons } from '@ionic/angular/standalone';
 import { DataService } from '../services/data.service';
-import { CommonModule, NgFor, NgIf, TitleCasePipe } from '@angular/common';
-import { IonGrid } from '@ionic/angular';
-import { Router } from '@angular/router';
-
-interface Pokemon {
-  name: string;
-  sprites: {
-    front_default: string;
-  };
-  types: {
-    type: {
-      name: string;
-    };
-  }[];
-}
+import { CommonModule } from '@angular/common';
+import { Router, RouterLink } from '@angular/router';
+import { NgxPaginationModule } from 'ngx-pagination';
+import { FavoritesService } from '../services/favorites.service';
+import { addIcons } from 'ionicons';
+import { heart, heartOutline } from 'ionicons/icons';
 
 @Component({
   selector: 'app-home',
@@ -36,43 +16,70 @@ interface Pokemon {
   styleUrls: ['home.page.scss'],
   standalone: true,
   imports: [
-    IonHeader,
-    IonToolbar,
-    IonTitle,
-    IonContent,
-    IonCard,
-    IonCardContent,
-    IonCardHeader,
-    NgFor,
-    CommonModule,
-    IonCardContent,
-    IonCardHeader,
-    IonCardTitle,
-  ],
+    IonHeader, IonToolbar, IonTitle, IonContent, IonCard, 
+    IonCardContent, IonCardHeader, IonCardTitle, CommonModule, 
+    NgxPaginationModule, IonButton, IonIcon, IonButtons, RouterLink
+  ]
 })
-export class HomePage {
+export class HomePage implements OnInit {
   pokemons: any[] = [];
+  page = 1;
+  totalPokemons = 0;
+  favoritePokemons: Set<string> = new Set();
 
-  constructor(private dataService: DataService, private router: Router) {}
+  constructor(
+    private dataService: DataService,
+    private router: Router,
+    private favoritesService: FavoritesService
+  ) {
+    addIcons({ heart, heartOutline });
+  }
+
+  async ngOnInit() {
+    await this.loadFavorites();
+    this.getPokemons();
+  }
+
+  async loadFavorites() {
+    const favorites = await this.favoritesService.getFavorites();
+    this.favoritePokemons = new Set(favorites.map((p: any) => p.name));
+  }
+
+  isFavorite(pokemonName: string): boolean {
+    return this.favoritePokemons.has(pokemonName);
+  }
+
+  async toggleFavorite(pokemon: any, event: Event) {
+    event.stopPropagation();
+    
+    if (this.isFavorite(pokemon.name)) {
+      await this.favoritesService.removeFavorite(pokemon.name);
+    } else {
+      await this.favoritesService.addFavorite(pokemon);
+    }
+    
+    await this.loadFavorites();
+  }
+
+  getPokemons() {
+    this.dataService
+      .getPokemons(50, (this.page - 1) * 50)
+      .subscribe((response: any) => {
+        this.totalPokemons = response.count;
+
+        response.results.forEach((result: any) => {
+          this.dataService
+            .getPokemonDetails(result.name)
+            .subscribe((uniqueResponse: any) => {
+              this.pokemons.push(uniqueResponse);
+            });
+        });
+      });
+  }
 
   openPokemonDetail(pokemon: any) {
     this.router.navigate(['/pokemon-detail'], {
       state: { pokemon },
     });
-  }
-
-  ngOnInit(): void {
-    this.dataService
-      .getPokemons()
-      .subscribe((response: { results: { name: string; url: string }[] }) => {
-        response.results.forEach((result: { name: string; url: string }) => {
-          this.dataService
-            .getPokemonDetails(result.name)
-            .subscribe((uniqueResponse: any) => {
-              this.pokemons.push(uniqueResponse);
-              console.log(this.pokemons);
-            });
-        });
-      });
   }
 }

--- a/pokedex-app/src/app/services/data.service.ts
+++ b/pokedex-app/src/app/services/data.service.ts
@@ -10,11 +10,11 @@ export class DataService {
 
   constructor(private http: HttpClient) { }
 
-  getPokemons(limit: number = 151): Observable<any> {
-    return this.http.get(`${this.apiUrl}/pokemon?limit=${limit}`);
+  getPokemons(limit: number = 50, offset: number = 0): Observable<any> {
+    return this.http.get(`${this.apiUrl}/pokemon?limit=${limit}&offset=${offset}`);
   }
 
-  getPokemonDetails(name: string) {
+  getPokemonDetails(name: string): Observable<any> {
     return this.http.get(`${this.apiUrl}/pokemon/${name}`);
   }
 }

--- a/pokedex-app/src/app/services/favorites.service.ts
+++ b/pokedex-app/src/app/services/favorites.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { Storage } from '@ionic/storage-angular';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FavoritesService {
+  private _storage: Storage | null = null;
+
+  constructor(private storage: Storage) {
+    this.init();
+  }
+
+  async init() {
+    this._storage = await this.storage.create();
+  }
+
+  async addFavorite(pokemon: any): Promise<void> {
+    const favorites = await this.getFavorites();
+    if (!favorites.some((fav: any) => fav.name === pokemon.name)) {
+      favorites.push(pokemon);
+      await this._storage?.set('favorites', favorites);
+    }
+  }
+
+  async removeFavorite(pokemonName: string): Promise<void> {
+    let favorites = await this.getFavorites();
+    favorites = favorites.filter((fav: any) => fav.name !== pokemonName);
+    await this._storage?.set('favorites', favorites);
+  }
+
+  async getFavorites(): Promise<any[]> {
+    return (await this._storage?.get('favorites')) || [];
+  }
+
+  async isFavorite(pokemonName: string): Promise<boolean> {
+    const favorites = await this.getFavorites();
+    return favorites.some((fav: any) => fav.name === pokemonName);
+  }
+}

--- a/pokedex-app/src/app/services/storage-wrapper.service.ts
+++ b/pokedex-app/src/app/services/storage-wrapper.service.ts
@@ -1,0 +1,19 @@
+// storage-wrapper.service.ts
+import { Injectable } from '@angular/core';
+import { Storage } from '@ionic/storage-angular';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class StorageWrapper {
+  private _storage: Storage | null = null;
+
+  constructor(private storage: Storage) {}
+
+  async ready() {
+    if (!this._storage) {
+      this._storage = await this.storage.create();
+    }
+    return this._storage;
+  }
+}

--- a/pokedex-app/src/global.scss
+++ b/pokedex-app/src/global.scss
@@ -23,7 +23,7 @@
 @import "@ionic/angular/css/float-elements.css";
 @import "@ionic/angular/css/text-alignment.css";
 @import "@ionic/angular/css/text-transformation.css";
-@import "@ionic/angular/css/flex-utils.css";
+// @import "@ionic/angular/css/flex-utils.css";
 
 /**
  * Ionic Dark Mode

--- a/pokedex-app/src/main.ts
+++ b/pokedex-app/src/main.ts
@@ -1,16 +1,5 @@
 import { bootstrapApplication } from '@angular/platform-browser';
-import { RouteReuseStrategy, provideRouter, withPreloading, PreloadAllModules } from '@angular/router';
-import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular/standalone';
-import { provideHttpClient } from '@angular/common/http';
-
-import { routes } from './app/app.routes';
+import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
 
-bootstrapApplication(AppComponent, {
-  providers: [
-    { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
-    provideIonicAngular(),
-    provideRouter(routes, withPreloading(PreloadAllModules)),
-    provideHttpClient(),    
-  ],
-});
+bootstrapApplication(AppComponent, appConfig);


### PR DESCRIPTION
- Implement pagination (50 Pokémon per page)
- Add navigation controls (next/previous pages)
- Create new '/favorites' route to display favorited Pokémon
- Preserve favorite state across pagination